### PR TITLE
Undo full paths, not pixels

### DIFF
--- a/build/make8bitart.js
+++ b/build/make8bitart.js
@@ -8,7 +8,7 @@ $(function() {
 
   /*** VARIABULLS ***/
 
-  var ctx, pickerPaletteCtx, leftSide, topSide, xPos, yPos, resetSelectStart, saveSelection, rect, historyPointer;
+  var ctx, pickerPaletteCtx, leftSide, topSide, xPos, yPos, resetSelectStart, saveSelection, rect, historyPointer, drawPathId;
   var undoRedoHistory = [];
   var drawHistory = [];
 
@@ -249,7 +249,7 @@ $(function() {
 
     if ( !areColorsEqual( hoverRGB, pixel.color, pixel.size) ) {
       drawPixel(e.pageX, e.pageY, pixel.color, pixel.size);
-      pushToHistory(action.index, action.draw, e.pageX, e.pageY, hoverRGB, pixel.color, pixel.size);
+      pushToHistory(action.index, action.draw, e.pageX, e.pageY, hoverRGB, pixel.color, pixel.size, drawPathId);
     }
   };
 
@@ -404,7 +404,7 @@ $(function() {
     }
   };
 
-  var pushToHistory = function( actionIndex, actionType, x, y, rgbOriginal, rgbNew, pixelSize) {
+  var pushToHistory = function( actionIndex, actionType, x, y, rgbOriginal, rgbNew, pixelSize, drawPathId) {
     // push to undoRedoHistory
     var pixelDrawn = {
       index : actionIndex,
@@ -413,7 +413,8 @@ $(function() {
       yPos : y,
       originalColor : rgbOriginal,
       newColor : rgbNew,
-      pixelSize: pixelSize
+      pixelSize: pixelSize,
+      drawPathId: drawPathId,
     };
     undoRedoHistory.push(pixelDrawn);
     drawHistory.push(pixelDrawn);
@@ -443,6 +444,17 @@ $(function() {
     }
 
     drawPixel(undoRedoHistory[pointer].xPos, undoRedoHistory[pointer].yPos, undoRedoColor, undoRedoHistory[pointer].pixelSize);
+
+    if (undoRedoHistory[pointer].drawPathId &&
+        undoRedoHistory[nextPointer] &&
+        undoRedoHistory[nextPointer].drawPathId == undoRedoHistory[pointer].drawPathId) {
+      if (undoFlag) {
+        undoRedo(--historyPointer, undoFlag);
+      }
+      else {
+        undoRedo(++historyPointer, undoFlag);
+      }
+    }
   };
 
   var resetModes = function() {
@@ -762,6 +774,8 @@ $(function() {
         paint( e.pageX, e.pageY, pixel.color, origRGB );
       }
       else {
+        drawPathId = Date.now();
+
         // draw mode
         mode.drawing = true;
 
@@ -769,7 +783,7 @@ $(function() {
         drawPixel(e.pageX, e.pageY, pixel.color, pixel.size);
 
         if ( !areColorsEqual( origRGB, pixel.color) ) {
-          pushToHistory(action.index, action.draw, e.pageX, e.pageY, origRGB, pixel.color, pixel.size);
+          pushToHistory(action.index, action.draw, e.pageX, e.pageY, origRGB, pixel.color, pixel.size, drawPathId);
         }
 
         DOM.$canvas.on('mousemove', drawOnMove);
@@ -802,6 +816,8 @@ $(function() {
     if ( !mode.save ) {
       DOM.$canvas.off('mousemove');
       mode.drawing = false;
+
+      drawPathId = null;
 
       // save
       saveToLocalStorage();

--- a/js/app/make8bitart.js
+++ b/js/app/make8bitart.js
@@ -8,7 +8,7 @@ $(function() {
 
   /*** VARIABULLS ***/
 
-  var ctx, pickerPaletteCtx, leftSide, topSide, xPos, yPos, resetSelectStart, saveSelection, rect, historyPointer;
+  var ctx, pickerPaletteCtx, leftSide, topSide, xPos, yPos, resetSelectStart, saveSelection, rect, historyPointer, drawPathId;
   var undoRedoHistory = [];
   var drawHistory = [];
 
@@ -249,7 +249,7 @@ $(function() {
 
     if ( !areColorsEqual( hoverRGB, pixel.color, pixel.size) ) {
       drawPixel(e.pageX, e.pageY, pixel.color, pixel.size);
-      pushToHistory(action.index, action.draw, e.pageX, e.pageY, hoverRGB, pixel.color, pixel.size);
+      pushToHistory(action.index, action.draw, e.pageX, e.pageY, hoverRGB, pixel.color, pixel.size, drawPathId);
     }
   };
 
@@ -404,7 +404,7 @@ $(function() {
     }
   };
 
-  var pushToHistory = function( actionIndex, actionType, x, y, rgbOriginal, rgbNew, pixelSize) {
+  var pushToHistory = function( actionIndex, actionType, x, y, rgbOriginal, rgbNew, pixelSize, drawPathId) {
     // push to undoRedoHistory
     var pixelDrawn = {
       index : actionIndex,
@@ -413,7 +413,8 @@ $(function() {
       yPos : y,
       originalColor : rgbOriginal,
       newColor : rgbNew,
-      pixelSize: pixelSize
+      pixelSize: pixelSize,
+      drawPathId: drawPathId,
     };
     undoRedoHistory.push(pixelDrawn);
     drawHistory.push(pixelDrawn);
@@ -443,6 +444,17 @@ $(function() {
     }
 
     drawPixel(undoRedoHistory[pointer].xPos, undoRedoHistory[pointer].yPos, undoRedoColor, undoRedoHistory[pointer].pixelSize);
+
+    if (undoRedoHistory[pointer].drawPathId &&
+        undoRedoHistory[nextPointer] &&
+        undoRedoHistory[nextPointer].drawPathId == undoRedoHistory[pointer].drawPathId) {
+      if (undoFlag) {
+        undoRedo(--historyPointer, undoFlag);
+      }
+      else {
+        undoRedo(++historyPointer, undoFlag);
+      }
+    }
   };
 
   var resetModes = function() {
@@ -762,6 +774,8 @@ $(function() {
         paint( e.pageX, e.pageY, pixel.color, origRGB );
       }
       else {
+        drawPathId = Date.now();
+
         // draw mode
         mode.drawing = true;
 
@@ -769,7 +783,7 @@ $(function() {
         drawPixel(e.pageX, e.pageY, pixel.color, pixel.size);
 
         if ( !areColorsEqual( origRGB, pixel.color) ) {
-          pushToHistory(action.index, action.draw, e.pageX, e.pageY, origRGB, pixel.color, pixel.size);
+          pushToHistory(action.index, action.draw, e.pageX, e.pageY, origRGB, pixel.color, pixel.size, drawPathId);
         }
 
         DOM.$canvas.on('mousemove', drawOnMove);
@@ -802,6 +816,8 @@ $(function() {
     if ( !mode.save ) {
       DOM.$canvas.off('mousemove');
       mode.drawing = false;
+
+      drawPathId = null;
 
       // save
       saveToLocalStorage();


### PR DESCRIPTION
[fixes #30]

Strategy: store a unique `drawPathId` when we start drawing. Each pixel that gets pushed to the history also stores this ID. When an `undo` or `redo` action happens, if the `nextPointer` points to an action with the same `drawPathId`, recurse until it doesn't.